### PR TITLE
Fix database path to use writable /tmp directory

### DIFF
--- a/backend/database.js
+++ b/backend/database.js
@@ -5,7 +5,23 @@ const path = require('path');
 let db;
 
 function initializeDatabase() {
-  const dbPath = process.env.FEEDBACK_DB_PATH || './feedback.db';
+  // Use environment-specific default paths if FEEDBACK_DB_PATH is not set
+  let defaultPath = './feedback.db';
+  
+  if (!process.env.FEEDBACK_DB_PATH) {
+    // Determine default path based on NODE_ENV or PORT
+    const port = process.env.PORT;
+    if (port === '3002') {
+      defaultPath = '/tmp/flippi-dev-feedback.db';  // Development
+    } else if (port === '3001') {
+      defaultPath = '/tmp/flippi-staging-feedback.db';  // Staging
+    } else if (port === '3000') {
+      defaultPath = '/tmp/flippi-feedback.db';  // Production
+    }
+    console.log(`No FEEDBACK_DB_PATH set, using default for port ${port}: ${defaultPath}`);
+  }
+  
+  const dbPath = process.env.FEEDBACK_DB_PATH || defaultPath;
   
   console.log('Initializing database at:', dbPath);
   console.log('Current working directory:', process.cwd());

--- a/backend/routes/feedback.js
+++ b/backend/routes/feedback.js
@@ -3,6 +3,15 @@ const router = express.Router();
 const { body, validationResult } = require('express-validator');
 const { getDatabase } = require('../database');
 
+// GET /api/feedback/test - Simple test endpoint
+router.get('/test', (req, res) => {
+  res.json({
+    success: true,
+    message: 'Feedback API is reachable',
+    timestamp: new Date().toISOString()
+  });
+});
+
 // GET /api/feedback/health - Check if feedback system is working
 router.get('/health', (req, res) => {
   try {
@@ -60,10 +69,16 @@ const feedbackValidation = [
 
 // POST /api/feedback
 router.post('/', feedbackValidation, (req, res) => {
+  console.log('Feedback POST request received');
+  console.log('Request body keys:', Object.keys(req.body));
+  console.log('helped_decision type:', typeof req.body.helped_decision);
+  console.log('helped_decision value:', req.body.helped_decision);
+  
   try {
     // Check validation errors
     const errors = validationResult(req);
     if (!errors.isEmpty()) {
+      console.error('Validation errors:', errors.array());
       return res.status(400).json({
         success: false,
         error: 'Invalid request',


### PR DESCRIPTION
## Fix for Internal Server Error

The issue was that the database was trying to write to `./feedback.db` in the current working directory, which may not be writable on the server.

## Changes
1. **Use /tmp directory**: Changed default database location to `/tmp` which is writable by all users
2. **Environment-specific files**: 
   - Development: `/tmp/flippi-dev-feedback.db`
   - Staging: `/tmp/flippi-staging-feedback.db`
   - Production: `/tmp/flippi-feedback.db`
3. **Added debugging**:
   - Request logging to see what data is being sent
   - Test endpoint at `/api/feedback/test`

## Testing
After deployment:
1. Check: https://blue.flippi.ai/api/feedback/test
2. Check: https://blue.flippi.ai/api/feedback/health
3. Try submitting feedback again

🤖 Generated with [Claude Code](https://claude.ai/code)